### PR TITLE
fix(FEC-14195): convert flashvars with string true and false values to boolean

### DIFF
--- a/src/v2-to-v7/embeds-converter.ts
+++ b/src/v2-to-v7/embeds-converter.ts
@@ -19,6 +19,11 @@ const attachV2Events = (targetId: string, kalturaPlayer: Player): void => {
   }
 };
 
+const addClassNameToParent = (targetId: string): void => {
+  // add kWidgetIframeContainer className to the parent element for kms styling purposes
+  document.getElementById(targetId)?.parentElement?.classList.add('kWidgetIframeContainer');
+};
+
 const v2PlayerEmbed = (v2Config: any) => {
   const {targetId, partnerId, mediaInfo} = getConfigIdsFromV2Config(v2Config);
 
@@ -31,6 +36,8 @@ const v2PlayerEmbed = (v2Config: any) => {
 
   const convertedFlashvars = getConfigFromFlashvars(v2Config.flashvars);
   const mergedConfig = mergeDeep(config, convertedFlashvars);
+
+  addClassNameToParent(targetId);
 
   try {
     const kalturaPlayer: Player = KalturaPlayer.setup(mergedConfig);
@@ -61,6 +68,8 @@ const V2PlayerThumbEmbed = (v2Config: any) => {
 
     const convertedFlashvars = getConfigFromFlashvars(v2Config.flashvars);
     const mergedConfig = mergeDeep(config, convertedFlashvars);
+
+    addClassNameToParent(targetId);
 
     const thumbnailEmbedConfig: ThumbnailEmbedOptions = {
       config: mergedConfig,

--- a/src/v2-to-v7/utils/flashvars-handler.ts
+++ b/src/v2-to-v7/utils/flashvars-handler.ts
@@ -59,7 +59,8 @@ export const buildConfigFromFlashvars = (flashvars: Record<string, any>): Record
 
       newKeyPathParts.forEach((newKey, index) => {
         if (index === newKeyPathParts.length - 1) {
-          current[newKey] = flashvars[key];
+          const value = flashvars[key];
+          current[newKey] = value === "true" || value === "false" ? JSON.parse(value) : value;
         } else {
           if (!current[newKey]) {
             current[newKey] = {};


### PR DESCRIPTION
**the issue:**
when passing flashvars with value `"true"` or `"false"` (as string type), player V7 will also get them in strings, while it expects booleans.

**fix:**
convert "true" and "false" string values to boolean.