### PR TITLE
fix(FEC-14215): expose domReady api on kWidget

### DIFF
--- a/src/thumbnail-embed/thumbnail-embed.ts
+++ b/src/thumbnail-embed/thumbnail-embed.ts
@@ -1,6 +1,6 @@
 import {ThumbnailEmbedComponent} from './thumbnail-embed-component';
 import {KalturaPlayer, Player, PlayerWindow} from '../types';
-import {ListenerDetails} from '../v2-to-v7/types';
+import {ListenerDetails, Callback} from '../v2-to-v7/types';
 import {attachV7Listener} from '../v2-to-v7/events-converter';
 import {attachV2API} from '../v2-to-v7/utils/api-converter';
 
@@ -31,7 +31,7 @@ const getCdnUrl = (config: any) => {
   return DEFAULT_CDN_URL;
 };
 
-const thumbnailEmbed = ({config, mediaInfo, mediaOptions = {}, version, bgColor}: ThumbnailEmbedOptions, isV2ToV7 = false) => {
+const thumbnailEmbed = ({config, mediaInfo, mediaOptions = {}, version, bgColor}: ThumbnailEmbedOptions, isV2ToV7 = false, readyCallbacks: Callback[] = []) => {
   if (!(config && mediaInfo)) {
     return;
   }
@@ -56,6 +56,7 @@ const thumbnailEmbed = ({config, mediaInfo, mediaOptions = {}, version, bgColor}
       listenersQueue.push({eventName, eventCallback: callback});
     };
     attachV2API(targetId);
+    readyCallbacks.forEach(cb => cb(targetId));
   }
 
   let width = DEFAULT_WIDTH;

--- a/src/v2-to-v7/index.ts
+++ b/src/v2-to-v7/index.ts
@@ -1,9 +1,11 @@
-import {v2PlayerEmbed, V2PlayerThumbEmbed} from './embeds-converter';
+import {v2PlayerEmbed, V2PlayerThumbEmbed, addReadyCallback} from './embeds-converter';
 import {buildV7Config} from './utils/flashvars-handler';
 
 (window as any).kWidget = {
   embed: v2PlayerEmbed,
-  thumbEmbed: V2PlayerThumbEmbed
+  thumbEmbed: V2PlayerThumbEmbed,
+  domReady: (cb: () => void) => cb(),
+  addReadyCallback: addReadyCallback
 };
 
 (window as any).__buildV7Config = buildV7Config;

--- a/src/v2-to-v7/types/callback.ts
+++ b/src/v2-to-v7/types/callback.ts
@@ -1,0 +1,1 @@
+export type Callback = (...args: any[]) => void;

--- a/src/v2-to-v7/types/index.ts
+++ b/src/v2-to-v7/types/index.ts
@@ -1,5 +1,6 @@
 import {ConfigFromV2} from "./config-from-v2";
 import {ListenerDetails} from "./listener-details";
 import {MediaInfo} from "./media-info";
+import {Callback} from "./callback";
 
-export {ConfigFromV2, ListenerDetails, MediaInfo};
+export {ConfigFromV2, ListenerDetails, MediaInfo, Callback};

--- a/src/v2-to-v7/utils/api-converter.ts
+++ b/src/v2-to-v7/utils/api-converter.ts
@@ -31,7 +31,6 @@ const addKWidgetAPI = (targetId: string): void => {
     isIE8: () => false,
     isAndroid: () => /Android/i.test(ua),
     isWindowsDevice: () => /Windows/i.test(ua),
-    addReadyCallback: () => {},
     destroy: () => getPlayer(targetId)?.destroy() || {},
     api: () => {},
     apiOptions: () => {},


### PR DESCRIPTION
**the issue:**
load of playlist inside KMS fails.

**root cause:**
usage of `domReady` api which we do not support.

**solution:**
- expose `domReady` api on kWidget
- expose `addReadyCallback` api on kWidget - support it when it is invoked before and after embed happens

Solves [FEC-14215](https://kaltura.atlassian.net/browse/FEC-14215)

[FEC-14215]: https://kaltura.atlassian.net/browse/FEC-14215?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ