### PR TITLE
fix(SUP-46543):convert event callbacks to function

### DIFF
--- a/src/thumbnail-embed/thumbnail-embed.ts
+++ b/src/thumbnail-embed/thumbnail-embed.ts
@@ -53,7 +53,7 @@ const thumbnailEmbed = ({config, mediaInfo, mediaOptions = {}, version, bgColor}
   let listenersQueue: ListenerDetails[] = [];
   if (isV2ToV7) {
     const addListenerToQueue = (eventName: string, callback: () => void) => {
-      listenersQueue.push({eventName, eventCallback: callback});
+      listenersQueue.push({eventName, eventCb: callback});
     };
     (playerDiv as any).addJsListener = addListenerToQueue;
     (playerDiv as any).kBind = addListenerToQueue;

--- a/src/v2-to-v7/embeds-converter.ts
+++ b/src/v2-to-v7/embeds-converter.ts
@@ -15,7 +15,7 @@ const attachV2Events = (targetId: string, kalturaPlayer: Player): void => {
   const playerDiv = document.getElementById(targetId);
   if (playerDiv) {
     const attachListener = (eventName: string, callback: () => void) => {
-      attachV7Listener({eventName, eventCallback: callback}, kalturaPlayer);
+      attachV7Listener({eventName, eventCb: callback}, kalturaPlayer);
     };
     (playerDiv as any).addJsListener = attachListener;
     (playerDiv as any).kBind = attachListener

--- a/src/v2-to-v7/events-converter.ts
+++ b/src/v2-to-v7/events-converter.ts
@@ -30,9 +30,9 @@ const eventsKeyMapping: Record<string, string> = {
 };
 
 const convertEventCallbackToFunction = (eventCb: string): Callback => {
-  const funcParts = eventCb.split('.');
+  const funcPathParts = eventCb.split('.');
   let func: any = window;
-  for (let part of funcParts) {
+  for (let part of funcPathParts) {
     func = func[part];
   }
   return func;

--- a/src/v2-to-v7/events-converter.ts
+++ b/src/v2-to-v7/events-converter.ts
@@ -1,4 +1,4 @@
-import {ListenerDetails} from './types';
+import {Callback, ListenerDetails} from './types';
 import {Player} from '../types';
 import {logger} from './utils/utils';
 
@@ -29,8 +29,20 @@ const eventsKeyMapping: Record<string, string> = {
   "playlistReady": "kaltura-player-playlistloaded",
 };
 
+const convertEventCallbackToFunction = (eventCb: string): Callback => {
+  const funcParts = eventCb.split('.');
+  let func: any = window;
+  for (let part of funcParts) {
+    func = func[part];
+  }
+  return func;
+};
+
 export const attachV7Listener = (listenerDetails: ListenerDetails, kalturaPlayer: Player) => {
-  const { eventName, eventCallback } = listenerDetails;
+  const { eventName, eventCb } = listenerDetails;
+
+  // event callback can be a string that represents the path to the callback function - convert it to function
+  const eventCallback: Callback = typeof eventCb === 'string' ? convertEventCallbackToFunction(eventCb) : eventCb;
 
   if (eventsKeyMapping[eventName]) {
     kalturaPlayer.addEventListener(eventsKeyMapping[eventName], () => {

--- a/src/v2-to-v7/types/listener-details.ts
+++ b/src/v2-to-v7/types/listener-details.ts
@@ -1,6 +1,8 @@
+import {Callback} from "./callback";
+
 interface ListenerDetails {
   eventName: string;
-  eventCallback: (...args: any[]) => void;
+  eventCb: string | Callback;
 }
 
 export {ListenerDetails};


### PR DESCRIPTION
there are cases where the `eventCallback` in v2-to-v7 flow can come as a `string`; happens mostly in kms cases, which gives a path to the function location as a string.

**in this pr:** before attaching the event to kalturaPlayer, check the `eventCallback` type; in case of a string, convert the path string to the function itself.

Resolves SUP-46543